### PR TITLE
バリデーションの設定、注文ビューの編集と新規配送先の登録を可能にしました。

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
-    autoprefixer-rails (9.7.6)
+    autoprefixer-rails (9.8.1)
       execjs
     bcrypt (3.1.13)
     bindex (0.8.1)
@@ -130,7 +130,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -156,7 +156,7 @@ GEM
     orm_adapter (0.5.0)
     public_suffix (4.0.5)
     puma (3.12.6)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,40 @@
 module ApplicationHelper
 end
+
+module ActionView
+  module Helpers
+    module FormHelper
+      def error_messages!(object_name, options = {})
+        resource = self.instance_variable_get("@#{object_name}")
+        return '' if !resource || resource.errors.empty?
+
+        messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+
+        html = <<-HTML
+          <div class="alert alert-danger">
+            <ul>#{messages}</ul>
+          </div>
+        HTML
+
+        html.html_safe
+      end
+
+      def error_css(object_name, method, options = {})
+        resource = self.instance_variable_get("@#{object_name}")
+        return '' if resource.errors.empty?
+
+        resource.errors.include?(method) ? 'has-error' : ''
+      end
+    end
+
+    class FormBuilder
+      def error_messages!(options = {})
+        @template.error_messages!(@object_name, options.merge(object: @object))
+      end
+
+      def error_css(method, options = {})
+        @template.error_css(@object_name, method, options.merge(object: @object))
+      end
+    end
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -15,4 +15,10 @@ module OrdersHelper
     end
     shippings_of_customer
   end
+
+  def find_product_name(order) # 注文データ一つ分を代入する
+    order_details = OrderDetail.where(order_id: order.id).pluck(:product_id)
+    Product.find(order_details).pluck(:name)
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,5 +4,7 @@ class Order < ApplicationRecord
   enum payment: { クレジットカード:  1, 銀行振込: 2}
   enum status: {入金待ち: 1,入金確認: 2,製作中: 3,発送準備中: 4,発送済み: 5}
 
+  validates :postal_code, presence: true, length: { is: 7 }
+  validates :address,:name,:payment,:total_fee,:select, presence: true
   attr_accessor :select,:shipping
 end

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -59,6 +59,7 @@
     <%= f.hidden_field :address %>
     <%= f.hidden_field :name %>
     <%= f.hidden_field :payment %>
+    <%= f.hidden_field :select %>
 
   <%= f.submit '購入を確定する',class:"btn btn-success btn-lg col-md-4 col-md-offset-4" %>
 </div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,43 +1,59 @@
 
 <h2>注文情報入力</h2>
 
-<div class="row">
+<%= form_for @order,url: orders_confirm_path,method: :post,html: {class:"form-inline"} do |f| %>
+<%= f.error_messages! %>
 
-  <%= form_for @order,url: orders_confirm_path,method: :post do |f| %>
+<div class="row">
+  <div class="col-md-10 col-md-offset-1">
 
   <h3>支払方法</h3>
-    <label><%= f.radio_button :payment, "クレジットカード" %>クレジットカード</label></br>
-    <label><%= f.radio_button :payment, "銀行振込" %>銀行振込</label>
+    <div class="col-md-offset-1">
+      <label><%= f.radio_button :payment, "クレジットカード" %>クレジットカード</label></br>
+      <label><%= f.radio_button :payment, "銀行振込" %>銀行振込</label>
+    </div>
 
   <h3>お届け先</h3>
-    <div>
-      <label><%= f.radio_button :select,"1" %>
-      ご自身の住所</label></br>
-        <%= customer_joint_address(current_customer) %></br>
+    <div class="col-md-offset-1">
+
+      <label><%= f.radio_button :select,"1" %>ご自身の住所</label></br>
+
+      <div class="row">
+        <p class="col-md-offset-1">  <%= customer_joint_address(current_customer) %></p>
+      </div>
+
+      <label><%= f.radio_button :select,"2" %>登録済住所から選択</label></br>
+
+      <div class="rows">
+        <%= f.select :shipping,shipping_array(current_customer),{},{class:"col-xs-offset-1 form-control"} %>
+      </div>
+
+
+      <label><%= f.radio_button :select,"3" %>新しいお届け先</label></br>
+
+      <div class="col-md-offset-1">
+        <div class="row">
+          <%= f.label :postal_code, '郵便番号(ハイフンなし)',class:"col-md-3" %>
+          <%= f.text_field :postal_code, class:"col-md-6 form-control" %>
+        </div>
+      </div>
+      <div class="col-md-offset-1">
+        <div class="row">
+          <%= f.label :address, '住所',class:"col-md-3" %>
+          <%= f.text_field :address, class:"col-md-6 form-control",size: 50 %>
+        </div>
+      </div>
+      <div class="col-md-offset-1">
+        <div class="row">
+          <%= f.label :name, '宛名',class:"col-md-3" %>
+          <%= f.text_field :name,class:"col-xs-6 form-control " %>
+        </div>
+      </div>
+
     </div>
 
-    <div>
-      <label><%= f.radio_button :select,"2" %>
-      登録済住所から選択</label></br>
-        <%= f.select :shipping,shipping_array(current_customer) %>
-    </div>
-
-    <div>
-      <label><%= f.radio_button :select,"3" %>
-      新しいお届け先</label></br>
-      <div>
-        <%= f.label :postal_code, '郵便番号(ハイフンなし)' %>
-        <%= f.text_field :postal_code %>
-      </div>
-      <div>
-        <%= f.label :address, '住所' %>
-        <%= f.text_field :address %>
-      </div>
-      <div>
-        <%= f.label :name, '宛名' %>
-        <%= f.text_field :name %>
-      </div>
-    </div>
-    <%= f.submit '確認画面へ進む',class:"btn btn-primary " %>
-  <% end %>
+  </div>
+    <%= f.submit '確認画面へ進む',class:"btn btn-primary col-md-2 col-md-offset-5" %>
 </div>
+
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module NaganoCAKE
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,10 @@ Rails.application.routes.draw do
   resources :products,only: [:index,:show]
   resources :shippings,only: [:new,:create,:edit,:update,:destroy]
   post '/orders/confirm' => "orders#confirm"
-  post '/orders/complete' => "orders#create"
   get '/orders/complete' => "orders#complete"
+  post '/orders/complete' => "orders#create"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :orders,only: [:new,:index,:show]
+  resources :orders,only: [:new,:create,:index,:show]
   root to: 'home#top'
   namespace :admin do
   	get '/' => "home#top"


### PR DESCRIPTION
# 注文機能の細かいところ編集
行ったこと：

- 注文テーブルに保存する情報の全てにバリデーションを加えました。
- 注文情報入力ページのレイアウトをととのえました。
- 新規配送先を入力して購入した場合に、入力内容を新規配送先住所として保存できるようにしました。
- ヘルパーに、注文に紐づく商品の名前を取得するヘルパーメソッドを定義しました。（みんなで作ったやつ）